### PR TITLE
Added travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+   - docker
+
+script:
+  - travis_wait 120 sleep infinity & docker build Dockerfile/CentOS


### PR DESCRIPTION
I added a travis file to get some continuous integration set up. What I would propose to do is that you go to https://travis-ci.org and couple it to this repo. Then every commit will trigger a build and you'll get an email if it fails. You can also setup a cron job in their settings that basically tries doing a build every day/week/month so that you basically regularly check that dependencies haven't broken. 

It would eventually be very neat to add some tests (moving the build progress to a pre-test block) to see if the build is actually useful, but that's surely of later concern. Also building smaller containers that depend on eachother may make the testing faster because of dockers caching system.